### PR TITLE
杂项修复以及重构

### DIFF
--- a/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/main/detail/illust/IllustDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/main/detail/illust/IllustDetailScreen.kt
@@ -217,7 +217,7 @@ private fun IllustTopAppBar(
                     onClick = onOriginImageRequest,
                 )
             }
-            if (currentPlatform !is Platform.Desktop) {
+            if (!useWideScreenMode) {
                 IconButton(
                     onClick = onCommentPanelBtnClick,
                     modifier = Modifier.padding(start = 8.dp),

--- a/composeApp/src/iosMain/kotlin/top/kagg886/pmf/ui/util/screen.ios.kt
+++ b/composeApp/src/iosMain/kotlin/top/kagg886/pmf/ui/util/screen.ios.kt
@@ -1,8 +1,11 @@
 package top.kagg886.pmf.ui.util
-
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.uikit.LocalUIViewController
+import platform.UIKit.UIUserInterfaceSizeClassRegular
 
-// TODO ios Adaptive UI
 @get:Composable
 actual val useWideScreenMode: Boolean
-    get() = false
+    get() {
+        val traitCollection = LocalUIViewController.current.traitCollection
+        return traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular
+    }


### PR DESCRIPTION
1. 移除平板模式下插画详情页的多余按钮
2. 为iOS平台添加窗口监听