### PR TITLE
fix padding on iOS on keyword mode.

### DIFF
--- a/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/main/search/v2/SearchPanelScreen.kt
+++ b/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/main/search/v2/SearchPanelScreen.kt
@@ -148,7 +148,7 @@ fun SearchPanelScreen(route: SearchPanelRoute) {
                     }
                     TextField(
                         value = state.text,
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier.fillMaxWidth().windowInsetsPadding(TopAppBarDefaults.windowInsets),
                         onValueChange = { model.updateText(it) },
                         leadingIcon = {
                             IconButton(onClick = { stack.removeLastOrNullWorkaround() }) {


### PR DESCRIPTION
<img width="444" height="947" alt="PixPin_2026-03-09_14-48-49" src="https://github.com/user-attachments/assets/5d60ab43-516f-478f-8508-ca685f6f055d" />
