### PR TITLE
fix(desktop): fallback folder picker to JFileChooser on macOS

### DIFF
--- a/lib/file-picker/src/jvmMain/kotlin/top/kagg886/filepicker/filekit.jvm.kt
+++ b/lib/file-picker/src/jvmMain/kotlin/top/kagg886/filepicker/filekit.jvm.kt
@@ -1,7 +1,8 @@
 package top.kagg886.filepicker
 
+import java.awt.FileDialog
+import java.awt.Frame
 import java.io.File
-import javax.swing.JFileChooser
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okio.Path
@@ -19,6 +20,21 @@ actual object FilePicker {
 }
 
 private val isMacOS by lazy { System.getProperty("os.name")?.startsWith("Mac") == true }
+private const val MACOS_FILE_DIALOG_FOR_DIRECTORIES = "apple.awt.fileDialogForDirectories"
+
+private inline fun <T> withMacOSDirectoryFileDialog(block: () -> T): T {
+    val previous = System.getProperty(MACOS_FILE_DIALOG_FOR_DIRECTORIES)
+    System.setProperty(MACOS_FILE_DIALOG_FOR_DIRECTORIES, "true")
+    return try {
+        block()
+    } finally {
+        if (previous == null) {
+            System.clearProperty(MACOS_FILE_DIALOG_FOR_DIRECTORIES)
+        } else {
+            System.setProperty(MACOS_FILE_DIALOG_FOR_DIRECTORIES, previous)
+        }
+    }
+}
 
 actual suspend fun FilePicker.openFileSaver(
     suggestedName: String,
@@ -48,17 +64,24 @@ suspend fun FilePicker.openFolderPicker(
 ) = withContext(Dispatchers.Main) {
     // rfd's macOS folder picker deadlocks/crashes when called from the JVM/AWT event thread.
     if (isMacOS) {
-        val chooser = directory?.toString()?.let(::File)?.let(::JFileChooser) ?: JFileChooser()
-        chooser.fileSelectionMode = JFileChooser.DIRECTORIES_ONLY
-        chooser.isAcceptAllFileFilterUsed = false
-        if (!title.isNullOrBlank()) {
-            chooser.dialogTitle = title
-        }
-        val result = chooser.showOpenDialog(null)
-        return@withContext if (result == JFileChooser.APPROVE_OPTION) {
-            chooser.selectedFile?.absolutePath?.toPath()
-        } else {
-            null
+        return@withContext withMacOSDirectoryFileDialog {
+            val dialog = FileDialog(null as Frame?, title ?: "", FileDialog.LOAD)
+            dialog.isMultipleMode = false
+            directory?.toString()?.let { dialog.directory = it }
+            try {
+                dialog.isVisible = true
+                dialog.files?.firstOrNull()?.absolutePath?.toPath()
+                    ?: dialog.file?.let { selected ->
+                        val parent = dialog.directory
+                        if (parent.isNullOrBlank()) {
+                            selected.toPath()
+                        } else {
+                            File(parent, selected).absolutePath.toPath()
+                        }
+                    }
+            } finally {
+                dialog.dispose()
+            }
         }
     }
 

--- a/lib/file-picker/src/jvmMain/kotlin/top/kagg886/filepicker/filekit.jvm.kt
+++ b/lib/file-picker/src/jvmMain/kotlin/top/kagg886/filepicker/filekit.jvm.kt
@@ -46,8 +46,7 @@ suspend fun FilePicker.openFolderPicker(
     title: String? = null,
     directory: Path? = null,
 ) = withContext(Dispatchers.Main) {
-    // rfd native folder picker can crash on macOS in JVM desktop runtime.
-    // Use Swing directory chooser as a stable fallback.
+    // rfd's macOS folder picker deadlocks/crashes when called from the JVM/AWT event thread.
     if (isMacOS) {
         val chooser = directory?.toString()?.let(::File)?.let(::JFileChooser) ?: JFileChooser()
         chooser.fileSelectionMode = JFileChooser.DIRECTORIES_ONLY

--- a/lib/file-picker/src/jvmMain/kotlin/top/kagg886/filepicker/filekit.jvm.kt
+++ b/lib/file-picker/src/jvmMain/kotlin/top/kagg886/filepicker/filekit.jvm.kt
@@ -1,5 +1,7 @@
 package top.kagg886.filepicker
 
+import java.io.File
+import javax.swing.JFileChooser
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okio.Path
@@ -15,6 +17,8 @@ actual object FilePicker {
         NativeFilePicker()
     }
 }
+
+private val isMacOS by lazy { System.getProperty("os.name")?.startsWith("Mac") == true }
 
 actual suspend fun FilePicker.openFileSaver(
     suggestedName: String,
@@ -42,6 +46,23 @@ suspend fun FilePicker.openFolderPicker(
     title: String? = null,
     directory: Path? = null,
 ) = withContext(Dispatchers.Main) {
+    // rfd native folder picker can crash on macOS in JVM desktop runtime.
+    // Use Swing directory chooser as a stable fallback.
+    if (isMacOS) {
+        val chooser = directory?.toString()?.let(::File)?.let(::JFileChooser) ?: JFileChooser()
+        chooser.fileSelectionMode = JFileChooser.DIRECTORIES_ONLY
+        chooser.isAcceptAllFileFilterUsed = false
+        if (!title.isNullOrBlank()) {
+            chooser.dialogTitle = title
+        }
+        val result = chooser.showOpenDialog(null)
+        return@withContext if (result == JFileChooser.APPROVE_OPTION) {
+            chooser.selectedFile?.absolutePath?.toPath()
+        } else {
+            null
+        }
+    }
+
     val ptr = nativeFilePicker.openDictionaryPicker(title, directory?.toString())
     withContext(Dispatchers.IO) {
         nativeFilePicker.awaitPointer(ptr)?.toPath()

--- a/lib/file-picker/src/rust/src/jvm.rs
+++ b/lib/file-picker/src/rust/src/jvm.rs
@@ -74,14 +74,27 @@ pub fn openFilePicker(env: EnvUnowned, _class: JClass, ext: JObjectArray<JString
 #[jni_mangle("top.kagg886.filepicker.internal.NativeFilePicker")]
 pub fn openDictionaryPicker(env: EnvUnowned, _class: JClass, title: JString, directory: JString) -> *mut FFIClosure {
     enter_jni(env, |env| {
-        let dir = if directory.is_null() { String::from("~") } else { directory.try_to_string(env)? };
-        let mut dialog = AsyncFileDialog::new().set_directory(dir);
-        if !title.is_null() {
-            let title: String = title.try_to_string(env)?;
-            dialog = dialog.set_title(title)
+        #[cfg(target_os = "macos")]
+        {
+            let _ = env;
+            let _ = title;
+            let _ = directory;
+            eprintln!("[filepicker/rfd] native folder picker disabled on macOS; use JVM Swing fallback");
+            let bo = Box::new(FFIClosure { f: Box::new(|| None) });
+            return Ok(Box::into_raw(bo));
         }
-        let fut = dialog.pick_folder();
-        let bo = Box::new(FFIClosure { f: Box::new(|| block_on(fut)) });
-        Ok(Box::into_raw(bo))
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            let dir = if directory.is_null() { String::from("~") } else { directory.try_to_string(env)? };
+            let mut dialog = AsyncFileDialog::new().set_directory(dir);
+            if !title.is_null() {
+                let title: String = title.try_to_string(env)?;
+                dialog = dialog.set_title(title)
+            }
+            let fut = dialog.pick_folder();
+            let bo = Box::new(FFIClosure { f: Box::new(|| block_on(fut)) });
+            Ok(Box::into_raw(bo))
+        }
     })
 }


### PR DESCRIPTION
## Summary
Fixes a macOS desktop crash when selecting the download root folder.

On macOS, `rfd` async folder picking can crash in our JVM/Compose Desktop runtime context.  
This PR adds a **temporary macOS-only fallback** to `JFileChooser` for `openFolderPicker`, while keeping the native path unchanged on other platforms.

## Scope
- Changed: `lib/file-picker/src/jvmMain/kotlin/top/kagg886/filepicker/filekit.jvm.kt`
- macOS: use `JFileChooser` (`DIRECTORIES_ONLY`)
- non-macOS: keep existing native `rfd` flow

## Why
The failure seems to be in the upstream `rfd` macOS async dialog path (thread/window constraints), not in app business logic.

Related upstream references:
- `rfd` issue #104 (open): https://github.com/PolyMeilex/rfd/issues/104
- `rfd` issue #3 (closed, historical macOS crash): https://github.com/PolyMeilex/rfd/issues/3
- `rfd` crate docs (macOS async/threading notes): https://docs.rs/rfd/latest/rfd/

## Validation
- `:lib:file-picker:compileKotlinJvm`
- `:composeApp:compileKotlinDesktop`
- `:composeApp:packageDistributionForCurrentOS`

## Temporary Workaround
This is intended as a **workaround** and can be removed once upstream `rfd` macOS async behavior is fixed and verified stable in our runtime.