### PR TITLE
sni bypass功能修复

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -210,6 +210,7 @@ kotlin {
             implementation(compose.desktop.currentOs)
             implementation(libs.kotlinx.coroutines.swing)
             implementation(libs.ktor.client.okhttp)
+            implementation(libs.okhttp.dnsoverhttps)
             implementation(libs.ktor.client.java)
             implementation(libs.androidx.sqlite.bundled)
         }
@@ -218,6 +219,7 @@ kotlin {
             implementation(compose.preview)
             implementation(libs.androidx.activity.compose)
             implementation(libs.ktor.client.okhttp)
+            implementation(libs.okhttp.dnsoverhttps)
             implementation(libs.coil.gif)
             implementation(libs.androidx.documentfile)
         }

--- a/composeApp/src/androidMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-android.kt
+++ b/composeApp/src/androidMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-android.kt
@@ -11,9 +11,7 @@ import javax.net.ssl.*
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.yield
 import okhttp3.Dns
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -87,7 +85,6 @@ private data class SNIReplaceDNS(
                 }
             },
         ).getOrElse { emptyList() }
-
 
         val fallback = fallback[hostname]!!.flatMap { InetAddress.getAllByName(it)!!.toList() }
 

--- a/composeApp/src/androidMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-android.kt
+++ b/composeApp/src/androidMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-android.kt
@@ -1,80 +1,34 @@
 package top.kagg886.pmf.backend
 
-import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.net.InetAddress
 import java.net.Socket
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
-import java.util.Base64
-import javax.net.ssl.SNIHostName
-import javax.net.ssl.SSLContext
-import javax.net.ssl.SSLSocket
-import javax.net.ssl.SSLSocketFactory
-import javax.net.ssl.X509TrustManager
+import javax.net.ssl.*
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.selects.select
+import kotlinx.coroutines.yield
 import okhttp3.Dns
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
-import okhttp3.Request
+import okhttp3.dnsoverhttps.DnsOverHttps
 import top.kagg886.pmf.util.logger
-
-private fun buildDnsQuery(name: String): ByteArray {
-    val out = ByteArrayOutputStream()
-    // Header: ID=0, Flags=RD(0x0100), QDCOUNT=1, AN/NS/AR=0
-    out.write(byteArrayOf(0x00, 0x00, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00))
-    // QNAME
-    for (label in name.split(".")) {
-        out.write(label.length)
-        out.write(label.toByteArray(Charsets.US_ASCII))
-    }
-    out.write(0x00)
-    // QTYPE=A(1), QCLASS=IN(1)
-    out.write(byteArrayOf(0x00, 0x01, 0x00, 0x01))
-    return out.toByteArray()
-}
-
-// compression pointer
-private fun skipName(bytes: ByteArray, pos: Int): Int {
-    var p = pos
-    while (p < bytes.size) {
-        val len = bytes[p].toInt() and 0xFF
-        when {
-            len == 0 -> return p + 1
-            len and 0xC0 == 0xC0 -> return p + 2
-            else -> p += len + 1
-        }
-    }
-    return p
-}
-
-private fun parseDnsARecords(bytes: ByteArray): List<String> {
-    val ancount = ((bytes[6].toInt() and 0xFF) shl 8) or (bytes[7].toInt() and 0xFF)
-    if (ancount == 0) return emptyList()
-
-    // Skip header (12 bytes) and the single question entry
-    var pos = skipName(bytes, 12) + 4 // +4 for QTYPE + QCLASS
-
-    val addresses = mutableListOf<String>()
-    repeat(ancount) {
-        pos = skipName(bytes, pos)
-        val type = ((bytes[pos].toInt() and 0xFF) shl 8) or (bytes[pos + 1].toInt() and 0xFF)
-        val rdlength = ((bytes[pos + 8].toInt() and 0xFF) shl 8) or (bytes[pos + 9].toInt() and 0xFF)
-        pos += 10 // TYPE(2) + CLASS(2) + TTL(4) + RDLENGTH(2)
-        if (type == 1 && rdlength == 4) { // A record
-            addresses.add("${bytes[pos].toInt() and 0xFF}.${bytes[pos + 1].toInt() and 0xFF}.${bytes[pos + 2].toInt() and 0xFF}.${bytes[pos + 3].toInt() and 0xFF}")
-        }
-        pos += rdlength
-    }
-    return addresses
-}
 
 fun OkHttpClient.Builder.bypassSNIOnAndroid(
     queryUrl: String,
     dohTimeout: Int = 5,
     unsafeSSL: Boolean = true,
     fallback: Map<String, List<String>>,
-) = dns(SNIReplaceDNS(queryUrl, dohTimeout, unsafeSSL, fallback)).sslSocketFactory(BypassSSLSocketFactory, BypassTrustManager)
+) = dns(SNIReplaceDNS(queryUrl, dohTimeout, unsafeSSL, fallback))
+    .sslSocketFactory(
+        BypassSSLSocketFactory,
+        BypassTrustManager
+    )
 
 private data class SNIReplaceDNS(
     val queryUrl: String,
@@ -82,37 +36,75 @@ private data class SNIReplaceDNS(
     val unsafeSSL: Boolean = true,
     val fallback: Map<String, List<String>>,
 ) : Dns {
-    private val client = OkHttpClient.Builder().apply {
-        if (unsafeSSL) {
-            ignoreSSL()
-        }
-        callTimeout(dohTimeout.seconds.toJavaDuration())
-    }.build()
-    override fun lookup(hostname: String): List<InetAddress> {
+    private val dnsOverHttps = DnsOverHttps.Builder()
+        .client(
+            client = OkHttpClient.Builder().apply {
+                if (unsafeSSL) {
+                    ignoreSSL()
+                }
+                callTimeout(dohTimeout.seconds.toJavaDuration())
+            }.build()
+        )
+        .systemDns(Dns.SYSTEM)
+        .url(queryUrl.toHttpUrl())
+        .build()
+
+    override fun lookup(hostname: String): List<InetAddress> = runBlocking(Dispatchers.IO) {
         val host = when {
             hostname.endsWith("pixiv.net") -> "pixiv.net"
             else -> hostname
         }
-        val data = try {
-            val dnsQuery = Base64.getUrlEncoder().withoutPadding().encodeToString(buildDnsQuery(host))
-            val resp = client.newCall(
-                Request.Builder()
-                    .url("$queryUrl?dns=$dnsQuery")
-                    .header("Accept", "application/dns-message")
-                    .build(),
-            ).execute()
-            parseDnsARecords(resp.body!!.bytes()).map {
-                InetAddress.getByName(it)
-            }
-        } catch (e: Throwable) {
-            logger.w(e) { "query DoH failed, use system dns" }
 
-            Dns.SYSTEM.lookup("$host" + ".cdn.cloudflare.net") + fallback[hostname]!!.map { InetAddress.getAllByName(it)!!.toList() }.flatten()
+        val result = run {
+            val dohDeferred = async {
+                try {
+                    val result = dnsOverHttps.lookup(host)
+                    yield()
+                    if (result.isEmpty()) {
+                        logger.w("query DoH returned none, use system dns")
+                    }
+                    result
+                } catch (e: Exception) {
+                    yield()
+                    logger.w(e) { "query DoH failed, use system dns" }
+                    emptyList()
+                }
+            }
+
+            val systemDeferred = async {
+                try {
+                    val result = Dns.SYSTEM.lookup("$host.cdn.cloudflare.net")
+                    yield()
+                    if (result.isEmpty()) {
+                        logger.w("query DoH returned none, use system dns")
+                    }
+                    result
+                } catch (e: Exception) {
+                    yield()
+                    logger.w(e) { "query dns failed, use fallback dns" }
+                    emptyList()
+                }
+            }
+
+            select {
+                dohDeferred.onAwait { doh ->
+                    systemDeferred.cancel()
+                    doh
+                }
+
+                systemDeferred.onAwait { system ->
+                    val doh = dohDeferred.await()
+                    doh + system
+                }
+            }
         }
-        logger.d("DNS lookup $hostname result : $data")
-        return data
+
+        val fallback = fallback[hostname]!!.flatMap { InetAddress.getAllByName(it)!!.toList() }
+
+        (result + fallback).distinct()
     }
 }
+
 fun OkHttpClient.Builder.ignoreSSL() {
     val sslContext = SSLContext.getInstance("SSL")
     val trust = object : X509TrustManager {
@@ -149,7 +141,7 @@ private object BypassSSLSocketFactory : SSLSocketFactory() {
         val socket = factory.createSocket(paramSocket, host, port, autoClose) as SSLSocket
         val params = socket.getSSLParameters()
         params.serverNames = listOf(SNIHostName("pixiv.me"))
-        socket.setSSLParameters(params)
+        socket.sslParameters = params
         return socket
     }
 

--- a/composeApp/src/androidMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-android.kt
+++ b/composeApp/src/androidMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-android.kt
@@ -140,7 +140,7 @@ fun OkHttpClient.Builder.ignoreSSL() {
 private object BypassSSLSocketFactory : SSLSocketFactory() {
     private val factory: SSLSocketFactory by lazy {
         val context = SSLContext.getInstance("TLS")
-        context.init(null,null,null)
+        context.init(null, null, null)
         context.socketFactory
     }
 

--- a/composeApp/src/androidMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-android.kt
+++ b/composeApp/src/androidMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-android.kt
@@ -27,7 +27,7 @@ fun OkHttpClient.Builder.bypassSNIOnAndroid(
 ) = dns(SNIReplaceDNS(queryUrl, dohTimeout, unsafeSSL, fallback))
     .sslSocketFactory(
         BypassSSLSocketFactory,
-        BypassTrustManager
+        BypassTrustManager,
     )
 
 private data class SNIReplaceDNS(
@@ -43,7 +43,7 @@ private data class SNIReplaceDNS(
                     ignoreSSL()
                 }
                 callTimeout(dohTimeout.seconds.toJavaDuration())
-            }.build()
+            }.build(),
         )
         .systemDns(Dns.SYSTEM)
         .url(queryUrl.toHttpUrl())

--- a/composeApp/src/androidMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-android.kt
+++ b/composeApp/src/androidMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-android.kt
@@ -1,5 +1,7 @@
 package top.kagg886.pmf.backend
 
+import arrow.core.getOrElse
+import arrow.fx.coroutines.raceN
 import java.io.IOException
 import java.net.InetAddress
 import java.net.Socket
@@ -55,8 +57,8 @@ private data class SNIReplaceDNS(
             else -> hostname
         }
 
-        val result = run {
-            val dohDeferred = async {
+        val result = raceN(
+            {
                 try {
                     val result = dnsOverHttps.lookup(host)
                     yield()
@@ -69,9 +71,8 @@ private data class SNIReplaceDNS(
                     logger.w(e) { "query DoH failed, use system dns" }
                     emptyList()
                 }
-            }
-
-            val systemDeferred = async {
+            },
+            {
                 try {
                     val result = Dns.SYSTEM.lookup("$host.cdn.cloudflare.net")
                     yield()
@@ -84,20 +85,9 @@ private data class SNIReplaceDNS(
                     logger.w(e) { "query dns failed, use fallback dns" }
                     emptyList()
                 }
-            }
+            },
+        ).getOrElse { emptyList() }
 
-            select {
-                dohDeferred.onAwait { doh ->
-                    systemDeferred.cancel()
-                    doh
-                }
-
-                systemDeferred.onAwait { system ->
-                    val doh = dohDeferred.await()
-                    doh + system
-                }
-            }
-        }
 
         val fallback = fallback[hostname]!!.flatMap { InetAddress.getAllByName(it)!!.toList() }
 

--- a/composeApp/src/androidMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-android.kt
+++ b/composeApp/src/androidMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-android.kt
@@ -7,6 +7,7 @@ import java.net.Socket
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import java.util.Base64
+import javax.net.ssl.SNIHostName
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocket
 import javax.net.ssl.SSLSocketFactory
@@ -137,12 +138,19 @@ fun OkHttpClient.Builder.ignoreSSL() {
 }
 
 private object BypassSSLSocketFactory : SSLSocketFactory() {
+    private val factory: SSLSocketFactory by lazy {
+        val context = SSLContext.getInstance("TLS")
+        context.init(null,null,null)
+        context.socketFactory
+    }
+
     @Throws(IOException::class)
     override fun createSocket(paramSocket: Socket?, host: String?, port: Int, autoClose: Boolean): Socket {
-        val inetAddress = paramSocket!!.inetAddress
-        val sslSocket =
-            (getDefault().createSocket(inetAddress, port) as SSLSocket).apply { enabledProtocols = supportedProtocols }
-        return sslSocket
+        val socket = factory.createSocket(paramSocket, host, port, autoClose) as SSLSocket
+        val params = socket.getSSLParameters()
+        params.serverNames = listOf(SNIHostName("pixiv.me"))
+        socket.setSSLParameters(params)
+        return socket
     }
 
     override fun createSocket(paramString: String?, paramInt: Int): Socket? = null

--- a/composeApp/src/commonMain/composeResources/values-en/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-en/strings.xml
@@ -25,9 +25,7 @@
     <string name="bookmark_failed">Bookmark failed...</string>
     <string name="bookmark_settings">Bookmark Settings</string>
     <string name="bookmark_success">Bookmark success!</string>
-    <string name="bypass_intro">        In some regions, Pixiv access may be restricted.\n        We offer SNI Bypass and Proxy solutions.\n        SNI Bypass: Connects directly to Pixiv servers using special methods.\n        Proxy: Forwards requests through a proxy server.</string>
     <string name="bypass_none">Direct</string>
-    <string name="bypass_note">If you use embedded browser with VPN to login to Pixiv, please do not enable SNI bypass, otherwise the program will not be able to login normally.\nRestart required after changes.</string>
     <string name="bypass_proxy">Proxy</string>
     <string name="bypass_sni">SNI Bypass</string>
     <string name="bypass_solution">Connection Method</string>
@@ -214,7 +212,6 @@
     <string name="night_mode">Dark</string>
     <string name="night_mode_not_supported">Theme setting not supported in dark mode</string>
     <string name="no">No</string>
-    <string name="no_bypass">Direct</string>
     <string name="no_description">No description</string>
     <string name="no_description_novel">No description</string>
     <string name="no_file_selected">No file selected</string>
@@ -321,7 +318,6 @@
     <string name="single_column_width">Column Width</string>
     <string name="single_column_width_description">Current: %1$s</string>
     <string name="skip_setup">Skip</string>
-    <string name="sni_bypass">SNI Bypass</string>
     <string name="sort_date_asc">Oldest first</string>
     <string name="sort_date_desc">Newest first</string>
     <string name="sort_mode">Sort by</string>
@@ -362,8 +358,6 @@
     <string name="update_check_failed">Update check failed...</string>
     <string name="updates">Updates</string>
     <string name="use_browser_login">Browser Login</string>
-    <string name="use_proxy">Proxy</string>
-    <string name="use_sni_bypass">SNI Bypass</string>
     <string name="use_token_login">Token Login</string>
     <string name="user">User</string>
     <string name="user_info">User Info</string>

--- a/composeApp/src/commonMain/composeResources/values-zh-rTW/string.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh-rTW/string.xml
@@ -25,9 +25,7 @@
     <string name="bookmark_failed">收藏失敗...</string>
     <string name="bookmark_settings">收藏設定</string>
     <string name="bookmark_success">收藏成功！</string>
-    <string name="bypass_intro">在某些地區可能無法正常存取 Pixiv。\n 我們提供了 SNI 繞過和代理兩種連線方案。\n SNI 繞過：透過特殊方式直接連線 Pixiv 伺服器。\n 代理：透過代理伺服器轉發請求。</string>
     <string name="bypass_none">無</string>
-    <string name="bypass_note">如果您使用內嵌瀏覽器搭配 VPN (梯子) 登入 Pixiv，請不要開啟 SNI 繞過功能，否則程式將無法正常登入。\n啟用/停用此功能後，您需要重新啟動客戶端才能生效。</string>
     <string name="bypass_proxy">代理</string>
     <string name="bypass_sni">SNI 替換</string>
     <string name="bypass_solution">直連方案</string>
@@ -213,7 +211,6 @@
     <string name="night_mode">夜間模式</string>
     <string name="night_mode_not_supported">夜間模式的主題暫不支援設定</string>
     <string name="no">否</string>
-    <string name="no_bypass">不使用繞過措施</string>
     <string name="no_description">沒有簡介</string>
     <string name="no_description_novel">沒有簡介</string>
     <string name="no_file_selected">未選擇檔案</string>
@@ -320,7 +317,6 @@
     <string name="single_column_width">單欄寬度</string>
     <string name="single_column_width_description">控制作品牆頁面單欄的大小，目前值: %1$s</string>
     <string name="skip_setup">略過設定</string>
-    <string name="sni_bypass">SNI 繞過</string>
     <string name="sort_date_asc">時間遞增</string>
     <string name="sort_date_desc">時間遞減</string>
     <string name="sort_mode">排序方式</string>
@@ -361,8 +357,6 @@
     <string name="update_check_failed">更新檢查失敗...</string>
     <string name="updates">更新</string>
     <string name="use_browser_login">使用內嵌瀏覽器登入</string>
-    <string name="use_proxy">使用代理</string>
-    <string name="use_sni_bypass">使用 SNI 繞過</string>
     <string name="use_token_login">使用 Token 登入</string>
     <string name="user">使用者</string>
     <string name="user_info">個人資訊</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -25,9 +25,7 @@
     <string name="bookmark_failed">收藏失败...</string>
     <string name="bookmark_settings">收藏设置</string>
     <string name="bookmark_success">收藏成功！</string>
-    <string name="bypass_intro">        在某些地区可能无法正常访问Pixiv。\n        我们提供了SNI绕过和代理两种连接方案。\n        SNI绕过：通过特殊方式直接连接Pixiv服务器。\n        代理：通过代理服务器转发请求。</string>
     <string name="bypass_none">无</string>
-    <string name="bypass_note">如果您使用嵌入式浏览器搭配梯子登录pixiv，请不要开启SNI绕过功能，否则程序将无法正常登录。\n启用/禁用功能后，你需要重启客户端以生效。</string>
     <string name="bypass_proxy">代理</string>
     <string name="bypass_sni">SNI替换</string>
     <string name="bypass_solution">直连方案</string>
@@ -214,7 +212,6 @@
     <string name="night_mode">夜间模式</string>
     <string name="night_mode_not_supported">夜间模式的主题暂不支持设置</string>
     <string name="no">否</string>
-    <string name="no_bypass">不使用绕过措施</string>
     <string name="no_description">没有简介</string>
     <string name="no_description_novel">没有简介</string>
     <string name="no_file_selected">未选择文件</string>
@@ -321,7 +318,6 @@
     <string name="single_column_width">单列宽度</string>
     <string name="single_column_width_description">控制画廊页面单列的大小,当前值:%1$s</string>
     <string name="skip_setup">跳过设置</string>
-    <string name="sni_bypass">SNI绕过</string>
     <string name="sort_date_asc">时间升序</string>
     <string name="sort_date_desc">时间降序</string>
     <string name="sort_mode">排序方式</string>
@@ -362,8 +358,6 @@
     <string name="update_check_failed">更新检测失败...</string>
     <string name="updates">更新</string>
     <string name="use_browser_login">使用嵌入式浏览器登录</string>
-    <string name="use_proxy">使用代理</string>
-    <string name="use_sni_bypass">使用SNI阻断</string>
     <string name="use_token_login">使用token登录</string>
     <string name="user">用户</string>
     <string name="user_info">个人信息</string>

--- a/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/main/setting/SettingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/main/setting/SettingScreen.kt
@@ -955,27 +955,29 @@ fun SettingScreen() {
                 enter = expandVertically(),
                 exit = shrinkVertically(),
             ) {
-                SettingsSwitch(
-                    enabled = checkUpdateOnStart,
-                    state = showCheckSuccessToast,
-                    title = {
-                        Text(stringResource(Res.string.show_toast_when_latest))
-                    },
-                    onCheckedChange = {
-                        showCheckSuccessToast = it
-                    },
-                )
+                Column {
+                    SettingsSwitch(
+                        enabled = checkUpdateOnStart,
+                        state = showCheckSuccessToast,
+                        title = {
+                            Text(stringResource(Res.string.show_toast_when_latest))
+                        },
+                        onCheckedChange = {
+                            showCheckSuccessToast = it
+                        },
+                    )
 
-                SettingsSwitch(
-                    enabled = checkUpdateOnStart,
-                    state = showCheckFailedToast,
-                    title = {
-                        Text(stringResource(Res.string.show_toast_when_failed))
-                    },
-                    onCheckedChange = {
-                        showCheckFailedToast = it
-                    },
-                )
+                    SettingsSwitch(
+                        enabled = checkUpdateOnStart,
+                        state = showCheckFailedToast,
+                        title = {
+                            Text(stringResource(Res.string.show_toast_when_failed))
+                        },
+                        onCheckedChange = {
+                            showCheckFailedToast = it
+                        },
+                    )
+                }
             }
 
             SettingsMenuLink(

--- a/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/welcome/WelcomeModel.kt
+++ b/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/welcome/WelcomeModel.kt
@@ -77,7 +77,6 @@ sealed interface WelcomeViewState {
         LANGUAGE, // 语言
         WELCOME, // 欢迎
         THEME, // 配置主题
-        BYPASS, // SNI绕过
         DOWNLOAD, // 下载设置
         SHIELD, // 屏蔽R18，AI等
         FINISH, // 完成

--- a/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/welcome/WelcomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/welcome/WelcomeScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.Button
@@ -77,7 +76,6 @@ import top.kagg886.pmf.ui.component.icon.SystemSuggest
 import top.kagg886.pmf.ui.route.login.v2.LoginRoute
 import top.kagg886.pmf.ui.route.main.recommend.RecommendRoute
 import top.kagg886.pmf.ui.route.main.setting.getDownloadRootPath
-import top.kagg886.pmf.ui.route.welcome.WelcomeViewState.ConfigureSetting.BYPASS
 import top.kagg886.pmf.ui.route.welcome.WelcomeViewState.ConfigureSetting.DOWNLOAD
 import top.kagg886.pmf.ui.route.welcome.WelcomeViewState.ConfigureSetting.FINISH
 import top.kagg886.pmf.ui.route.welcome.WelcomeViewState.ConfigureSetting.LANGUAGE
@@ -136,7 +134,6 @@ private fun WelcomeContent(model: WelcomeModel, state0: WelcomeViewState) {
                                 LANGUAGE -> stringResource(Res.string.app_language)
                                 WELCOME -> stringResource(Res.string.welcome)
                                 THEME -> stringResource(Res.string.theme_setting)
-                                BYPASS -> stringResource(Res.string.sni_bypass)
                                 DOWNLOAD -> stringResource(Res.string.settings_download)
                                 SHIELD -> stringResource(Res.string.shield_config)
                                 FINISH -> stringResource(Res.string.setup_complete)
@@ -196,7 +193,6 @@ private fun WelcomeElementContent(
         LANGUAGE -> LanguageSelectionContent()
         WELCOME -> WelcomeTextContent()
         THEME -> ThemeSelectionContent()
-        BYPASS -> BypassSettingsContent()
         DOWNLOAD -> DownloadSettingsContent()
         SHIELD -> ShieldSettingsContent()
         FINISH -> FinishSetupContent()
@@ -395,87 +391,6 @@ private fun ThemeSelectionContent() {
                 )
                 append(stringResource(Res.string.theme_info_after_url))
             },
-            modifier = Modifier.padding(8.dp),
-        )
-    }
-}
-
-@Composable
-private fun BypassSettingsContent() {
-    Text(
-        stringResource(Res.string.bypass_intro),
-    )
-
-    var bypassSettings by remember {
-        mutableStateOf(AppConfig.bypassSettings)
-    }
-    LaunchedEffect(bypassSettings) {
-        AppConfig.bypassSettings = bypassSettings
-    }
-    Spacer(Modifier.height(16.dp))
-    Row(
-        horizontalArrangement = Arrangement.SpaceBetween,
-        modifier = Modifier.fillMaxWidth().height(IntrinsicSize.Min),
-    ) {
-        SelectionCard(
-            select = bypassSettings is AppConfig.BypassSetting.None,
-            modifier = Modifier.weight(1f).fillMaxHeight().padding(horizontal = 8.dp),
-            onClick = {
-                bypassSettings = AppConfig.BypassSetting.None
-            },
-        ) {
-            ListItem(
-                leadingContent = {
-                    Icon(Icons.Default.Delete, "")
-                },
-                headlineContent = {
-                    Text(stringResource(Res.string.no_bypass))
-                },
-                modifier = Modifier.fillMaxHeight().weight(1f),
-            )
-        }
-
-        SelectionCard(
-            select = bypassSettings is AppConfig.BypassSetting.SNIReplace,
-            modifier = Modifier.weight(1f).fillMaxHeight().padding(horizontal = 8.dp),
-            onClick = {
-                bypassSettings = AppConfig.BypassSetting.SNIReplace()
-            },
-        ) {
-            ListItem(
-                leadingContent = {
-                    Icon(Icons.Default.Check, "")
-                },
-                headlineContent = {
-                    Text(stringResource(Res.string.use_sni_bypass))
-                },
-                modifier = Modifier.fillMaxHeight().weight(1f),
-            )
-        }
-
-        SelectionCard(
-            select = bypassSettings is AppConfig.BypassSetting.Proxy,
-            modifier = Modifier.weight(1f).fillMaxHeight().padding(horizontal = 8.dp),
-            onClick = {
-                bypassSettings = AppConfig.BypassSetting.Proxy()
-            },
-        ) {
-            ListItem(
-                leadingContent = {
-                    Icon(Icons.Default.Check, "")
-                },
-                headlineContent = {
-                    Text(stringResource(Res.string.use_proxy))
-                },
-                modifier = Modifier.fillMaxHeight().weight(1f),
-            )
-        }
-    }
-    Spacer(Modifier.height(16.dp))
-
-    Card(Modifier.fillMaxWidth()) {
-        Text(
-            stringResource(Res.string.bypass_note),
             modifier = Modifier.padding(8.dp),
         )
     }

--- a/composeApp/src/desktopMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-desktop.kt
@@ -27,7 +27,7 @@ fun OkHttpClient.Builder.bypassSNIOnDesktop(
 ) = dns(SNIReplaceDNS(queryUrl, dohTimeout, unsafeSSL, fallback))
     .sslSocketFactory(
         BypassSSLSocketFactory,
-        BypassTrustManager
+        BypassTrustManager,
     )
 
 private data class SNIReplaceDNS(
@@ -43,7 +43,7 @@ private data class SNIReplaceDNS(
                     ignoreSSL()
                 }
                 callTimeout(dohTimeout.seconds.toJavaDuration())
-            }.build()
+            }.build(),
         )
         .systemDns(Dns.SYSTEM)
         .url(queryUrl.toHttpUrl())

--- a/composeApp/src/desktopMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-desktop.kt
@@ -11,9 +11,7 @@ import javax.net.ssl.*
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.yield
 import okhttp3.Dns
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -87,7 +85,6 @@ private data class SNIReplaceDNS(
                 }
             },
         ).getOrElse { emptyList() }
-
 
         val fallback = fallback[hostname]!!.flatMap { InetAddress.getAllByName(it)!!.toList() }
 

--- a/composeApp/src/desktopMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-desktop.kt
@@ -1,76 +1,34 @@
 package top.kagg886.pmf.backend
 
-import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.net.InetAddress
 import java.net.Socket
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
-import java.util.*
 import javax.net.ssl.*
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.selects.select
+import kotlinx.coroutines.yield
 import okhttp3.Dns
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
-import okhttp3.Request
+import okhttp3.dnsoverhttps.DnsOverHttps
 import top.kagg886.pmf.util.logger
-
-private fun buildDnsQuery(name: String): ByteArray {
-    val out = ByteArrayOutputStream()
-    // Header: ID=0, Flags=RD(0x0100), QDCOUNT=1, AN/NS/AR=0
-    out.write(byteArrayOf(0x00, 0x00, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00))
-    // QNAME
-    for (label in name.split(".")) {
-        out.write(label.length)
-        out.write(label.toByteArray(Charsets.US_ASCII))
-    }
-    out.write(0x00)
-    // QTYPE=A(1), QCLASS=IN(1)
-    out.write(byteArrayOf(0x00, 0x01, 0x00, 0x01))
-    return out.toByteArray()
-}
-
-// compression pointer
-private fun skipName(bytes: ByteArray, pos: Int): Int {
-    var p = pos
-    while (p < bytes.size) {
-        val len = bytes[p].toInt() and 0xFF
-        when {
-            len == 0 -> return p + 1
-            len and 0xC0 == 0xC0 -> return p + 2
-            else -> p += len + 1
-        }
-    }
-    return p
-}
-
-private fun parseDnsARecords(bytes: ByteArray): List<String> {
-    val ancount = ((bytes[6].toInt() and 0xFF) shl 8) or (bytes[7].toInt() and 0xFF)
-    if (ancount == 0) return emptyList()
-
-    // Skip header (12 bytes) and the single question entry
-    var pos = skipName(bytes, 12) + 4 // +4 for QTYPE + QCLASS
-
-    val addresses = mutableListOf<String>()
-    repeat(ancount) {
-        pos = skipName(bytes, pos)
-        val type = ((bytes[pos].toInt() and 0xFF) shl 8) or (bytes[pos + 1].toInt() and 0xFF)
-        val rdlength = ((bytes[pos + 8].toInt() and 0xFF) shl 8) or (bytes[pos + 9].toInt() and 0xFF)
-        pos += 10 // TYPE(2) + CLASS(2) + TTL(4) + RDLENGTH(2)
-        if (type == 1 && rdlength == 4) { // A record
-            addresses.add("${bytes[pos].toInt() and 0xFF}.${bytes[pos + 1].toInt() and 0xFF}.${bytes[pos + 2].toInt() and 0xFF}.${bytes[pos + 3].toInt() and 0xFF}")
-        }
-        pos += rdlength
-    }
-    return addresses
-}
 
 fun OkHttpClient.Builder.bypassSNIOnDesktop(
     queryUrl: String,
     dohTimeout: Int = 5,
     unsafeSSL: Boolean = true,
     fallback: Map<String, List<String>>,
-) = dns(SNIReplaceDNS(queryUrl, dohTimeout, unsafeSSL, fallback)).sslSocketFactory(BypassSSLSocketFactory, BypassTrustManager)
+) = dns(SNIReplaceDNS(queryUrl, dohTimeout, unsafeSSL, fallback))
+    .sslSocketFactory(
+        BypassSSLSocketFactory,
+        BypassTrustManager
+    )
 
 private data class SNIReplaceDNS(
     val queryUrl: String,
@@ -78,36 +36,75 @@ private data class SNIReplaceDNS(
     val unsafeSSL: Boolean = true,
     val fallback: Map<String, List<String>>,
 ) : Dns {
-    private val client = OkHttpClient.Builder().apply {
-        if (unsafeSSL) {
-            ignoreSSL()
-        }
-        callTimeout(dohTimeout.seconds.toJavaDuration())
-    }.build()
-    override fun lookup(hostname: String): List<InetAddress> {
+    private val dnsOverHttps = DnsOverHttps.Builder()
+        .client(
+            client = OkHttpClient.Builder().apply {
+                if (unsafeSSL) {
+                    ignoreSSL()
+                }
+                callTimeout(dohTimeout.seconds.toJavaDuration())
+            }.build()
+        )
+        .systemDns(Dns.SYSTEM)
+        .url(queryUrl.toHttpUrl())
+        .build()
+
+    override fun lookup(hostname: String): List<InetAddress> = runBlocking(Dispatchers.IO) {
         val host = when {
             hostname.endsWith("pixiv.net") -> "pixiv.net"
             else -> hostname
         }
-        val data = try {
-            val dnsQuery = Base64.getUrlEncoder().withoutPadding().encodeToString(buildDnsQuery(host))
-            val resp = client.newCall(
-                Request.Builder()
-                    .url("$queryUrl?dns=$dnsQuery")
-                    .header("Accept", "application/dns-message")
-                    .build(),
-            ).execute()
-            parseDnsARecords(resp.body!!.bytes()).map {
-                InetAddress.getByName(it)
-            }
-        } catch (e: Throwable) {
-            logger.w(e) { "query DoH failed, use system dns" }
 
-            Dns.SYSTEM.lookup("$host" + ".cdn.cloudflare.net") + fallback[hostname]!!.map { InetAddress.getAllByName(it)!!.toList() }.flatten()
+        val result = run {
+            val dohDeferred = async {
+                try {
+                    val result = dnsOverHttps.lookup(host)
+                    yield()
+                    if (result.isEmpty()) {
+                        logger.w("query DoH returned none, use system dns")
+                    }
+                    result
+                } catch (e: Exception) {
+                    yield()
+                    logger.w(e) { "query DoH failed, use system dns" }
+                    emptyList()
+                }
+            }
+
+            val systemDeferred = async {
+                try {
+                    val result = Dns.SYSTEM.lookup("$host.cdn.cloudflare.net")
+                    yield()
+                    if (result.isEmpty()) {
+                        logger.w("query DoH returned none, use system dns")
+                    }
+                    result
+                } catch (e: Exception) {
+                    yield()
+                    logger.w(e) { "query dns failed, use fallback dns" }
+                    emptyList()
+                }
+            }
+
+            select {
+                dohDeferred.onAwait { doh ->
+                    systemDeferred.cancel()
+                    doh
+                }
+
+                systemDeferred.onAwait { system ->
+                    val doh = dohDeferred.await()
+                    doh + system
+                }
+            }
         }
-        return data
+
+        val fallback = fallback[hostname]!!.flatMap { InetAddress.getAllByName(it)!!.toList() }
+
+        (result + fallback).distinct()
     }
 }
+
 fun OkHttpClient.Builder.ignoreSSL() {
     val sslContext = SSLContext.getInstance("SSL")
     val trust = object : X509TrustManager {
@@ -144,7 +141,7 @@ private object BypassSSLSocketFactory : SSLSocketFactory() {
         val socket = factory.createSocket(paramSocket, host, port, autoClose) as SSLSocket
         val params = socket.getSSLParameters()
         params.serverNames = listOf(SNIHostName("pixiv.me"))
-        socket.setSSLParameters(params)
+        socket.sslParameters = params
         return socket
     }
 

--- a/composeApp/src/desktopMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-desktop.kt
@@ -1,5 +1,7 @@
 package top.kagg886.pmf.backend
 
+import arrow.core.getOrElse
+import arrow.fx.coroutines.raceN
 import java.io.IOException
 import java.net.InetAddress
 import java.net.Socket
@@ -55,8 +57,8 @@ private data class SNIReplaceDNS(
             else -> hostname
         }
 
-        val result = run {
-            val dohDeferred = async {
+        val result = raceN(
+            {
                 try {
                     val result = dnsOverHttps.lookup(host)
                     yield()
@@ -69,9 +71,8 @@ private data class SNIReplaceDNS(
                     logger.w(e) { "query DoH failed, use system dns" }
                     emptyList()
                 }
-            }
-
-            val systemDeferred = async {
+            },
+            {
                 try {
                     val result = Dns.SYSTEM.lookup("$host.cdn.cloudflare.net")
                     yield()
@@ -84,20 +85,9 @@ private data class SNIReplaceDNS(
                     logger.w(e) { "query dns failed, use fallback dns" }
                     emptyList()
                 }
-            }
+            },
+        ).getOrElse { emptyList() }
 
-            select {
-                dohDeferred.onAwait { doh ->
-                    systemDeferred.cancel()
-                    doh
-                }
-
-                systemDeferred.onAwait { system ->
-                    val doh = dohDeferred.await()
-                    doh + system
-                }
-            }
-        }
 
         val fallback = fallback[hostname]!!.flatMap { InetAddress.getAllByName(it)!!.toList() }
 

--- a/composeApp/src/desktopMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-desktop.kt
@@ -15,7 +15,6 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import top.kagg886.pmf.util.logger
 
-
 private fun buildDnsQuery(name: String): ByteArray {
     val out = ByteArrayOutputStream()
     // Header: ID=0, Flags=RD(0x0100), QDCOUNT=1, AN/NS/AR=0
@@ -136,7 +135,7 @@ fun OkHttpClient.Builder.ignoreSSL() {
 private object BypassSSLSocketFactory : SSLSocketFactory() {
     private val factory: SSLSocketFactory by lazy {
         val context = SSLContext.getInstance("TLS")
-        context.init(null,null,null)
+        context.init(null, null, null)
         context.socketFactory
     }
 

--- a/composeApp/src/desktopMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/top/kagg886/pmf/backend/auto-fuck-china-desktop.kt
@@ -6,17 +6,15 @@ import java.net.InetAddress
 import java.net.Socket
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
-import java.util.Base64
-import javax.net.ssl.SSLContext
-import javax.net.ssl.SSLSocket
-import javax.net.ssl.SSLSocketFactory
-import javax.net.ssl.X509TrustManager
+import java.util.*
+import javax.net.ssl.*
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 import okhttp3.Dns
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import top.kagg886.pmf.util.logger
+
 
 private fun buildDnsQuery(name: String): ByteArray {
     val out = ByteArrayOutputStream()
@@ -136,12 +134,19 @@ fun OkHttpClient.Builder.ignoreSSL() {
 }
 
 private object BypassSSLSocketFactory : SSLSocketFactory() {
+    private val factory: SSLSocketFactory by lazy {
+        val context = SSLContext.getInstance("TLS")
+        context.init(null,null,null)
+        context.socketFactory
+    }
+
     @Throws(IOException::class)
     override fun createSocket(paramSocket: Socket?, host: String?, port: Int, autoClose: Boolean): Socket {
-        val inetAddress = paramSocket!!.inetAddress
-        val sslSocket =
-            (getDefault().createSocket(inetAddress, port) as SSLSocket).apply { enabledProtocols = supportedProtocols }
-        return sslSocket
+        val socket = factory.createSocket(paramSocket, host, port, autoClose) as SSLSocket
+        val params = socket.getSSLParameters()
+        params.serverNames = listOf(SNIHostName("pixiv.me"))
+        socket.setSSLParameters(params)
+        return socket
     }
 
     override fun createSocket(paramString: String?, paramInt: Int): Socket? = null

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ ksoup = "0.2.6"
 ksp = "2.3.5"
 ktor = "3.4.3"
 multiplatformSettings = "1.3.0"
+okhttp = "5.3.2"
 okio = "3.17.0"
 orbit = "11.0.0"
 paging = "3.4.2"
@@ -81,6 +82,7 @@ ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "kto
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatformSettings" }
 #multiplatform-settings-serialization = { module = "com.russhwolf:multiplatform-settings-serialization", version.ref = "multiplatformSettings" }
+okhttp-dnsoverhttps = { module = "com.squareup.okhttp3:okhttp-dnsoverhttps", version.ref = "okhttp" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 orbit-core = { module = "org.orbit-mvi:orbit-compose", version.ref = "orbit" }
 pixko = { module = "top.kagg886:pixko", version.ref = "pixko" }


### PR DESCRIPTION
说实话黑科技总感觉以后维护会很麻烦，不如大道至简。 

~~目前仅测试macOS，其他平台得下班再说~~

@UjuiUjuMandan 麻烦有空鉴定一下，

```kotlin
    private val factory: SSLSocketFactory by lazy {
        val context = SSLContext.getInstance("TLS")
        context.init(null,null,null)
        context.socketFactory
    }

    @Throws(IOException::class)
    override fun createSocket(paramSocket: Socket?, host: String?, port: Int, autoClose: Boolean): Socket {
        val socket = factory.createSocket(paramSocket, host, port, autoClose) as SSLSocket
        val params = socket.getSSLParameters()
        params.serverNames = listOf(SNIHostName("pixiv.me"))
        socket.setSSLParameters(params)
        return socket
    }
```

此外修复了一个设置页面的问题

考虑移除初始化页面的 bypass settings：因为登录页需要开启内置webview，此时一定需要挂代理。一旦登录成功走OAuth接口并开了代理，会导致cert verify failed